### PR TITLE
Add cache and adjust TOTALDELEGATIONS value

### DIFF
--- a/cosmos_directory.gs
+++ b/cosmos_directory.gs
@@ -101,7 +101,7 @@ async function COSMOSDIRECTORYBALANCE(chain, walletAddress, token) {
 async function COSMOSDIRECTORYTOTALDELEGATIONS(chain, valoper) {
     const validator = await get_validator(chain, valoper);
 
-    return validator.tokens;
+    return validator?.delegations?.total_tokens_display;
 }
 
 /**COSMOSDIRECTORYVALCOMMISSION

--- a/cosmos_directory.gs
+++ b/cosmos_directory.gs
@@ -101,7 +101,7 @@ async function COSMOSDIRECTORYBALANCE(chain, walletAddress, token) {
 async function COSMOSDIRECTORYTOTALDELEGATIONS(chain, valoper) {
     const validator = await get_validator(chain, valoper);
 
-    return validator?.delegations?.total_tokens_display;
+    return validator.tokens;
 }
 
 /**COSMOSDIRECTORYVALCOMMISSION


### PR DESCRIPTION
Thank you SO much for building this 🔥 

This PR adds a 5 minute cache to the chains and validator calls, and adjusts TOTALDELEGATIONS to return `delegations.total_tokens_display` instead of `tokens` which is in base denom format.

I'll do a bit more testing if you want to hold off merging until tomorrow, but seems fine initially